### PR TITLE
Centralize frontend API base URL via environment variables

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,2 @@
+# Local development API base URL
+REACT_APP_API_BASE_URL=http://localhost:4000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env.development or .env.production and adjust as needed.
+REACT_APP_API_BASE_URL=https://playas-cantabria.onrender.com

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,2 @@
+# Production API base URL
+REACT_APP_API_BASE_URL=https://playas-cantabria.onrender.com

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,0 +1,41 @@
+const DEFAULT_API_BASE_URL = 'https://playas-cantabria.onrender.com';
+
+const normalizeBaseUrl = (value: string): string => value.replace(/\/+$/, '');
+
+const resolveApiBaseUrl = (): string => {
+  const rawValue = process.env.REACT_APP_API_BASE_URL?.trim();
+
+  if (!rawValue) {
+    return DEFAULT_API_BASE_URL;
+  }
+
+  try {
+    const parsed = new URL(rawValue);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('Unsupported protocol');
+    }
+    return normalizeBaseUrl(parsed.toString());
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[config] Invalid REACT_APP_API_BASE_URL, falling back to default.',
+        error
+      );
+    }
+    return DEFAULT_API_BASE_URL;
+  }
+};
+
+/**
+ * Single source of truth for the API base URL.
+ * Override per-environment with REACT_APP_API_BASE_URL in .env files.
+ */
+export const API_BASE_URL = resolveApiBaseUrl();
+
+export const buildApiUrl = (path: string): string => {
+  if (!path) return API_BASE_URL;
+  return path.startsWith('/')
+    ? `${API_BASE_URL}${path}`
+    : `${API_BASE_URL}/${path}`;
+};

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,7 @@
+import { buildApiUrl } from '../config/api';
+
 export async function getPlayas(): Promise<Playa[]> {
-  // TO-DO - create varible out of it
-  //const res = await fetch('http://localhost:4000/api/playas');
-  const res = await fetch('https://playas-cantabria.onrender.com/api/beaches');
+  const res = await fetch(buildApiUrl('/api/beaches'));
   if (!res.ok) throw new Error('Error al obtener playas');
   return res.json();
 }
@@ -108,10 +108,8 @@ export interface PlayaDetalle {
   cruzRoja?: DatosCruzRoja;
 }
 
-
 export async function getDetallePlaya(codigo: string): Promise<PlayaDetalle> {
-  // const res = await fetch(`http://localhost:4000/api/playas/${codigo}`);
-  const res = await fetch(`https://playas-cantabria.onrender.com/api/beaches/${codigo}/details`);
+  const res = await fetch(buildApiUrl(`/api/beaches/${codigo}/details`));
 
   if (!res.ok) throw new Error('No se pudo cargar el detalle de la playa');
   return res.json();


### PR DESCRIPTION
### Motivation
- Replace hardcoded backend URLs scattered in the frontend with a single configurable source of truth so the app works for local development and production without code changes.
- Make the API base URL resilient to missing or invalid configuration and preserve existing behavior by falling back to the current production URL.

### Description
- Add `frontend/src/config/api.ts` which exposes `API_BASE_URL` and `buildApiUrl()` and validates/normalizes `process.env.REACT_APP_API_BASE_URL`, falling back to `https://playas-cantabria.onrender.com` when needed.
- Update `frontend/src/services/api.ts` to use `buildApiUrl('/api/beaches')` and `buildApiUrl(`/api/beaches/${codigo}/details`)` instead of hardcoded endpoints.
- Add environment files `frontend/.env.development`, `frontend/.env.production`, and `frontend/.env.example` containing `REACT_APP_API_BASE_URL` for dev and prod configuration.
- Keep existing behavior intact by defaulting to the previous production URL when no valid environment variable is provided, and log a warning in non-production when the variable is invalid.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983422c47e083339ae77ade08f0bbc0)